### PR TITLE
Fix newline text error

### DIFF
--- a/src/psql_functions.cpp
+++ b/src/psql_functions.cpp
@@ -14,7 +14,7 @@
  */
 
 #include <cstdlib>
-#include <algorithm>    // std::sort
+#include <algorithm>    // std::sort, std::remove
 #include <stack>
 
 #include "wilton/support/exception.hpp"
@@ -835,6 +835,8 @@ sl::json::value row::dump_to_json(){
     for (size_t i = 0; i < properties.size(); ++i) {
         std::string field_name = properties[i].name;
         std::string field_value = get_value_as_string(i);
+        // remove new line symbols
+        field_value.erase(std::remove(field_value.begin(), field_value.end(), '\n'), field_value.end());
         fields.emplace_back(field_name.c_str(), sl::json::loads(field_value));
     }
     json_res.set_object(std::move(fields));

--- a/src/psql_functions.cpp
+++ b/src/psql_functions.cpp
@@ -216,55 +216,7 @@ sl::json::value get_result_as_json(PGresult *res){
     return json;
 }
 
-void escape_quotes(std::string& val){
-    // need add escaping characters for '"' symbols
-    if (!val.size()) return;
-    std::stack<size_t> poses;
-    if ('\"' == val[0]){
-        poses.push(0);
-    }
-    for (size_t i = 1; i < val.size(); ++i) {
-        if ('\"' == val[i] && '\\' != val[i-1]) {
-            poses.push(i);
-        }
-    }
-    // only one resize
-    val.reserve(val.size() + poses.size());
-    while (poses.size()) {
-        val.insert(poses.top(), "\\");
-        poses.pop();
-    }
-}
-
-void escape_newlines(std::string& val){
-     // need add escaping characters for '\n' symbols
-    if (!val.size()) return;
-    std::stack<size_t> poses;
-    if ('\n' == val[0]){
-        poses.push(0);
-    }
-    for (size_t i = 1; i < val.size(); ++i) {
-        if ('\n' == val[i] && '\\' != val[i-1]) {
-            poses.push(i);
-        }
-    }
-    // only one resize
-    val.reserve(val.size() + poses.size());
-    while (poses.size()) {
-        // change '\n' to "\\n"
-        val[poses.top()] = 'n';
-        val.insert(poses.top(), "\\");
-        poses.pop();
-    }
-}
-
-void prepare_text(std::string& val){
-    escape_quotes(val);
-    escape_newlines(val);
-}
-
 void prepare_text_array(std::string& val) {
-    escape_newlines(val);
     enum class states {
         normal, in_string, manual_open
     };
@@ -848,8 +800,6 @@ std::string row::get_value_as_string(size_t value_pos){ // converts
     case PSQL_TEXTOID:
     case PSQL_VARCHAROID:
     default: {
-        prepare_text(val);
-        val = "\"" + val + "\"";
         break;
     }
     }
@@ -865,7 +815,8 @@ sl::json::value row::dump_to_json(){
     for (size_t i = 0; i < properties.size(); ++i) {
         std::string field_name = properties[i].name;
         std::string field_value = get_value_as_string(i);
-        fields.emplace_back(field_name.c_str(), sl::json::loads(field_value));
+        fields.emplace_back(field_name.c_str(),
+                            sl::json::value(field_value));
     }
     json_res.set_object(std::move(fields));
     return json_res;


### PR DESCRIPTION
Added escapes for newline('\n') symbols in text formats. '\n' converts to "\\n". Because jansson throws errors on '\n' symbols.